### PR TITLE
fix filename regexp by escape '.'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,10 +2,10 @@ const {resolve, dirname, join} = require("path");
 const {renderSync} = require("node-sass");
 
 const regexps = {
-  sassFile: /([A-Za-z0-9]+).s[ac]ss/g,
+  sassFile: /([A-Za-z0-9]+)\.s[ac]ss/g,
   sassExt: /\.s[ac]ss$/,
-  currentFile: /([A-Za-z0-9]+).(t|j)s(x)?/g,
-  currentFileExt: /.(t|j)s(x)?/g
+  currentFile: /([A-Za-z0-9]+)\.(t|j)s(x)?/g,
+  currentFileExt: /\.(t|j)s(x)?/
 };
 
 const isImportDefaultSpecifier = (node) =>


### PR DESCRIPTION
The current regexps match ts, js, tsx, jsx files but even all 'ts' ending words in the filepath.
Exemple :

My path looks like :

`MyProject/src/components/button/index.js`

will match :

['componen**ts** ', 'index.js']

then line 33 : 

```
const filename = `${file[0].replace(
          regexps.currentFileExt,
          ""
        )}_${sassFileName}`;
```

will catch 'components'.

To avoid this, we need to escape the '.' (dot) of the file extension by adding `\` right before.