### PR TITLE
[#22] Fix missing packages for Next.js React 18 environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "homepage": "https://github.com/altgifted/babel-plugin-transform-scss#readme",
   "peerDependencies": {
     "node-sass": "^8.0.0",
-    "path": "^0.12.7",
-    "sass": "^1.3.0"
+    "path": "^0.12.7"
   },
   "peerDependenciesMeta": {
     "node-sass": {
@@ -41,10 +40,14 @@
     }
   },
   "devDependencies": {
-    "node-sass": "^8.0.0",
-    "sass": "^1.35.2"
+    "node-sass": "^8.0.0"
   },
   "dependencies": {
-    "path": "^0.12.7"
+    "@babel/plugin-proposal-class-properties": "^7.18.6",
+    "@babel/plugin-proposal-private-methods": "^7.18.6",
+    "@babel/preset-react": "^7.23.3",
+    "path": "^0.12.7",
+    "sass": "^1.69.5",
+    "uuid": "^9.0.1"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/altgifted/babel-plugin-transform-scss/issues/22 with subsequent missing dependencies.

Tested on React 18 (Next.js) and React 17 (react-scripts@5.0.1).