### PR TITLE
support query parameters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,8 +21,8 @@ const {v4} = require('uuid')
 const {renderSync} = getDefaultSassImplementation();
 
 const regexps = {
-  sassFile: /([._\-A-Za-z0-9]+)\.s[ac]ss/g,
-  sassExt: /\.s[ac]ss$/,
+  sassFile: /([._\-A-Za-z0-9]+)\.s[ac]ss(\?\w+)?/g,
+  sassExt: /\.s[ac]ss(\?\w+)?$/,
   currentFile: /([A-Za-z0-9]+)\.(t|j)s(x)?/g,
   currentFileExt: /\.(t|j)s(x)?/
 };


### PR DESCRIPTION
for some reasons I need to keep compability with vite that requires to have ?inline query parameter

ex import 'style?.scss'

this fix allows to have imports with query parameter